### PR TITLE
Prepare configuration for Maven Central deployment.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,19 @@
+VERSION_NAME=1.4
+VERSION_CODE=4
+GROUP=lecho.lib.hellocharts.hellocharts-library
+
+POM_DESCRIPTION=Charting library for Android compatible with API 8+(Android 2.2). Works best when hardware acceleration is available, so API 14+(Android 4.0) is recommended.
+POM_URL=https://github.com/lecho/hellocharts-android
+POM_SCM_URL=https://github.com/lecho/hellocharts-android
+POM_SCM_CONNECTION=scm:git@github.com:lecho/hellocharts-android.git
+POM_SCM_DEV_CONNECTION=scm:git@github.com:lecho/hellocharts-android.git
+POM_LICENCE_NAME=The Apache Software License, Version 2.0
+POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_DIST=repo
+POM_DEVELOPER_ID=lecho
+POM_DEVELOPER_NAME=Leszek Wach
+
+ANDROID_BUILD_MIN_SDK_VERSION=8
+ANDROID_BUILD_TARGET_SDK_VERSION=21
+ANDROID_BUILD_TOOLS_VERSION=21.1.2
+ANDROID_BUILD_SDK_VERSION=21

--- a/hellocharts-library/build.gradle
+++ b/hellocharts-library/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
+apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
 
 buildscript {
     repositories {
@@ -17,8 +18,8 @@ dependencies {
 
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
+    buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
@@ -26,10 +27,10 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 21
-        versionCode 4
-        versionName '1.4'
+        minSdkVersion Integer.parseInt(project.ANDROID_BUILD_MIN_SDK_VERSION)
+        targetSdkVersion Integer.parseInt(project.ANDROID_BUILD_TARGET_SDK_VERSION)
+        versionCode Integer.parseInt(project.VERSION_CODE)
+        versionName project.VERSION_NAME
     }
 
     sourceSets {
@@ -57,11 +58,6 @@ android {
 
 }
 
-task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.sourceFiles
-}
-
 //Execute "gradle clean jarRelease" to cook jar.
 android.libraryVariants.all { variant ->
     def name = variant.buildType.name
@@ -85,6 +81,7 @@ publishing {
             groupId "lecho.lib.hellocharts"
             version android.defaultConfig.versionName
 
+            // Task androidSourcesJar is provided by gradle-mvn-push.gradle
             artifact androidSourcesJar {
                 classifier "sources"
             }

--- a/hellocharts-library/gradle.properties
+++ b/hellocharts-library/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=HelloCharts for Android Library
+POM_ARTIFACT_ID=hellocharts-library
+POM_PACKAGING=aar

--- a/hellocharts-samples/build.gradle
+++ b/hellocharts-samples/build.gradle
@@ -8,8 +8,8 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
+    buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
@@ -17,10 +17,10 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 21
-        versionCode 4
-        versionName '1.4'
+        minSdkVersion Integer.parseInt(project.ANDROID_BUILD_MIN_SDK_VERSION)
+        targetSdkVersion Integer.parseInt(project.ANDROID_BUILD_TARGET_SDK_VERSION)
+        versionCode Integer.parseInt(project.VERSION_CODE)
+        versionName project.VERSION_NAME
     }
 
     sourceSets {


### PR DESCRIPTION
+ Steps to do: Create `~/.gradle/gradle.properties` as described here:
  https://github.com/chrisbanes/gradle-mvn-push
+ Further information here: http://zserge.com/blog/gradle-maven-publish.html
+ See issue #71.

Please consider using [semantic versioning](http://semver.org) and a `GROUP` id which is owned by you. This can be either a domain or your GitHub repository: `GROUP=com.github.lecho.hellocharts-android` which can then be referenced via Gradle as `compile 'com.github.lecho.hellocharts-android:hellocharts-library:1.4'`.