### PR TITLE
Needes for xamarin binding to work

### DIFF
--- a/hellocharts-library/src/lecho/lib/hellocharts/animation/ChartAnimationListener.java
+++ b/hellocharts-library/src/lecho/lib/hellocharts/animation/ChartAnimationListener.java
@@ -4,7 +4,7 @@ package lecho.lib.hellocharts.animation;
  * Listener used to listen for chart animation start and stop events. Implementations of this interface can be used for
  * all types of chart animations(data, viewport, PieChart rotation).
  */
-public interface ChartAnimationListener {
+public interface ChartAnimationListener extends EventListener {
 
     public void onAnimationStarted();
 


### PR DESCRIPTION
Xamarin has problems when events have the same names making the binding fail. 
this fixes it.