### PR TITLE
prevent parent from scrolling if the chart can be scrolled (that is, …

### DIFF
--- a/hellocharts-library/src/lecho/lib/hellocharts/view/AbstractChartView.java
+++ b/hellocharts-library/src/lecho/lib/hellocharts/view/AbstractChartView.java
@@ -483,4 +483,17 @@ public abstract class AbstractChartView extends View implements Chart {
         this.touchHandler.resetTouchHandler();
     }
 
+    @Override
+    public boolean canScrollHorizontally(int direction) {
+        if (getZoomLevel() <= 1.0) {
+            return false;
+        }
+        final Viewport currentViewport = getCurrentViewport();
+        final Viewport maximumViewport = getMaximumViewport();
+        if (direction < 0) {
+            return currentViewport.left > maximumViewport.left;
+        } else {
+            return currentViewport.right < maximumViewport.right;
+        }
+    }
 }

--- a/hellocharts-library/src/lecho/lib/hellocharts/view/AbstractChartView.java
+++ b/hellocharts-library/src/lecho/lib/hellocharts/view/AbstractChartView.java
@@ -483,6 +483,14 @@ public abstract class AbstractChartView extends View implements Chart {
         this.touchHandler.resetTouchHandler();
     }
 
+    /**
+     * When embedded in a ViewPager, this will be called in order to know if we can scroll.
+     * If this returns true, the ViewPager will ignore the drag so that we can scroll our content.
+     * If this return false, the ViewPager will assume we won't be able to scroll and will consume the drag
+     *
+     * @param direction Amount of pixels being scrolled (x axis)
+     * @return true if the chart can be scrolled (ie. zoomed and not against the edge of the chart)
+     */
     @Override
     public boolean canScrollHorizontally(int direction) {
         if (getZoomLevel() <= 1.0) {


### PR DESCRIPTION
…zoomed and not against its edge vs. direction of scroll)

This allows the charts to be embedded in a `ViewPager` and swipeable tabs