### PR TITLE
Small LineChart improvements

### DIFF
--- a/hellocharts-library/src/lecho/lib/hellocharts/model/Line.java
+++ b/hellocharts-library/src/lecho/lib/hellocharts/model/Line.java
@@ -225,7 +225,7 @@ public class Line {
 
     public Line setCubic(boolean isCubic) {
         this.isCubic = isCubic;
-        if (isSquare)
+        if (isSquare && isCubic)
             setSquare(false);
         return this;
     }
@@ -236,7 +236,7 @@ public class Line {
 
     public Line setSquare(boolean isSquare) {
         this.isSquare = isSquare;
-        if (isCubic)
+        if (isCubic && isSquare)
             setCubic(false);
         return this;
     }

--- a/hellocharts-library/src/lecho/lib/hellocharts/renderer/LineChartRenderer.java
+++ b/hellocharts-library/src/lecho/lib/hellocharts/renderer/LineChartRenderer.java
@@ -249,17 +249,19 @@ public class LineChartRenderer extends AbstractChartRenderer {
         prepareLinePaint(line);
 
         int valueIndex = 0;
-        float previousRawY = 0;
+        float previousRawY = Float.NaN;
         for (PointValue pointValue : line.getValues()) {
 
             final float rawX = computator.computeRawX(pointValue.getX());
             final float rawY = computator.computeRawY(pointValue.getY());
 
-            if (valueIndex == 0) {
-                path.moveTo(rawX, rawY);
-            } else {
-                path.lineTo(rawX, previousRawY);
-                path.lineTo(rawX, rawY);
+            if (! Float.isNaN(rawY)) {
+                if (Float.isNaN(previousRawY)) {
+                    path.moveTo(rawX, rawY);
+                } else {
+                    path.lineTo(rawX, previousRawY);
+                    path.lineTo(rawX, rawY);
+                }
             }
 
             previousRawY = rawY;

--- a/hellocharts-library/src/lecho/lib/hellocharts/renderer/LineChartRenderer.java
+++ b/hellocharts-library/src/lecho/lib/hellocharts/renderer/LineChartRenderer.java
@@ -215,15 +215,21 @@ public class LineChartRenderer extends AbstractChartRenderer {
         prepareLinePaint(line);
 
         int valueIndex = 0;
+        boolean invalidYValue = false;
         for (PointValue pointValue : line.getValues()) {
 
             final float rawX = computator.computeRawX(pointValue.getX());
             final float rawY = computator.computeRawY(pointValue.getY());
 
-            if (valueIndex == 0) {
-                path.moveTo(rawX, rawY);
-            } else {
-                path.lineTo(rawX, rawY);
+            if (Float.isNaN(rawY))
+                invalidYValue = true;
+            else {
+                if (valueIndex == 0 || invalidYValue) {
+                    path.moveTo(rawX, rawY);
+                } else {
+                    path.lineTo(rawX, rawY);
+                }
+                invalidYValue = false;
             }
 
             ++valueIndex;


### PR DESCRIPTION
Greetings,

I changed LineChart so you can add Float.NaN Y values for line interruptions (invalid values). So far this works for the regular and square  lines only (all I need). Cubic is to be done.

Also, Line.setCubic(false) and Line.setSquare(false) would reset the respective other setting to false which is not expected. Even worse, Line.setSquare(true) would result in a regular line if Line.setCubic(true) was called before and vice versa.

This is my first pull request on github. I wondered if it made sense to separate those two unrelated concerns into two pull requests but could not find an obvious way to do so. In case I did something stupid please bear with me :)

moritz